### PR TITLE
fix: include files when publishing to npm

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ehbp",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "JavaScript client for Encrypted HTTP Body Protocol (EHBP)",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/js/package.json
+++ b/js/package.json
@@ -48,5 +48,10 @@
   },
   "engines": {
     "node": ">=20.0.0"
-  }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ]
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add a files field to js/package.json so npm publishes only dist, README.md, and LICENSE. Fixes missing build output and docs in the package and reduces package size.

<!-- End of auto-generated description by cubic. -->

